### PR TITLE
Fix psr-4 autoloading standard compliance

### DIFF
--- a/src/assetbundles/elementlink/ElementLinkAsset.php
+++ b/src/assetbundles/elementlink/ElementLinkAsset.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace marionnewlevant\elementlink\assetbundles\ElementLink;
+namespace marionnewlevant\elementlink\assetbundles\elementlink;
 
 use Craft;
 use craft\web\AssetBundle;


### PR DESCRIPTION
Fixes the deprecation notice in composer:

Deprecation Notice: Class marionnewlevant\elementlink\assetbundles\ElementLink\ElementLinkAsset located in ./vendor/marionnewlevant/element-link/src/assetbundles/elementlink/ElementLinkAsset.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201